### PR TITLE
Verify SSL to avoid writing errors to the log

### DIFF
--- a/service.subtitles.rvm.addic7ed/addic7ed/webclient.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/webclient.py
@@ -40,7 +40,7 @@ class Session(object):
         logger.debug('Opening URL: {0}'.format(url))
         self._session.headers['Referer'] = referer
         try:
-            response = self._session.get(url, params=params, verify=False)
+            response = self._session.get(url, params=params)
         except requests.RequestException:
             logger.error('Unable to connect to Addic7ed.com!')
             raise Add7ConnectionError


### PR DESCRIPTION
Revert e8c0a6d. Not verifying SSL is bad practice and generates an error in Kodi's log file:

```
2023-05-19 00:14:42.492 T:1924     info <general>: service.subtitles.rvm.addic7ed: Searching for subs...
2023-05-19 00:14:42.638 T:1924    error <general>: /usr/lib/python3.11/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.addic7ed.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
                                                     warnings.warn(
                                                   
2023-05-19 00:14:52.344 T:1924     info <general>: Skipped 1 duplicate messages..
```